### PR TITLE
Add Swedish voice option

### DIFF
--- a/index.html
+++ b/index.html
@@ -503,6 +503,15 @@
 
       <input type="range" min="1" max="7" value="7" class="zuluslider voiceslider" id="voicevolumeslider" oninput="getvoicesliders()">
 
+      <div class = "flashsettingstext">
+        <p class="flashlabel">Language: </p>
+      </div>
+
+      <select class="zuluselect" id="voicelanguage" onchange="setvoiceLanguage(this.value)">
+        <option value="en-US">English</option>
+        <option value="sv-SE">Svenska</option>
+      </select>
+
       <button class="zulubutton" id="voicetest" onclick="synthesisvoice('394 plus 921', voicerate)">Test voice</button>
 
       <button class="zulubutton" id="voicedone" onclick="removevoicecontainer(event, true)">Done</button>

--- a/template1eqs/additionfuncs.js
+++ b/template1eqs/additionfuncs.js
@@ -473,7 +473,12 @@ function addaddition(main=false,self=additionpreset,name=null){
 
 }
 
+
 function additionspeech(problem){
+
+  if(voiceLang.startsWith('sv')){
+    return (problem[0] < 0 ? "minus " : "") + Math.abs(problem[0]) + " plus " + (problem[1] < 0 ? "minus " : "") + Math.abs(problem[1]);
+  }
 
   return (problem[0] < 0 ? "negative " : "") + Math.abs(problem[0]) + " plus " + (problem[1] < 0 ? "negative " : "") + Math.abs(problem[1]);
 

--- a/template1eqs/celctoffuncs.js
+++ b/template1eqs/celctoffuncs.js
@@ -68,6 +68,10 @@ function addcelctof(main=false,self=celctofpreset,name=null){
 
 function celctofspeech(problem){
 
+  if(voiceLang.startsWith('sv')){
+    return problem[0] + " grader celsius";
+  }
+
   return problem[0] + " degrees celsius"
 
 

--- a/template1eqs/cmtoinfuncs.js
+++ b/template1eqs/cmtoinfuncs.js
@@ -68,6 +68,10 @@ function addcmtoin(main=false,self=cmtoinpreset,name=null){
 
 function cmtoinspeech(problem){
 
+  if(voiceLang.startsWith('sv')){
+    return problem[0] + " centimeter";
+  }
+
   return problem[0] + " centimeters"
 
 

--- a/template1eqs/division.js
+++ b/template1eqs/division.js
@@ -89,6 +89,10 @@ function adddivision(main=false,self=divisionpreset,name=null){
 
 function divisionspeech(problem){
 
+  if(voiceLang.startsWith('sv')){
+    return (problem[0] < 0 ? "minus " : "") + Math.abs(problem[0]) + " över " + (problem[1] < 0 ? "minus " : "") + Math.abs(problem[1]);
+  }
+
   return (problem[0] < 0 ? "negative " : "") + Math.abs(problem[0]) + " over " + (problem[1] < 0 ? "negative " : "") + Math.abs(problem[1]);
 
 

--- a/template1eqs/fractionfuncs.js
+++ b/template1eqs/fractionfuncs.js
@@ -64,6 +64,10 @@ function fractionspeech(problem){
   let frac1 = problem[0];
   let frac2 = problem[1];
 
+  if(voiceLang.startsWith('sv')){
+    return frac1[0] + " över " + frac1[1] + " plus " + frac2[0] + " över " + frac2[1];
+  }
+
   return frac1[0] + " over " + frac1[1] + " plus " + frac2[0] + " over " + frac2[1];
 
 }

--- a/template1eqs/ftocelcfuncs.js
+++ b/template1eqs/ftocelcfuncs.js
@@ -68,6 +68,10 @@ function addftocelc(main=false,self=ftocelcpreset,name=null){
 
 function ftocelcspeech(problem){
 
+  if(voiceLang.startsWith('sv')){
+    return problem[0] + " grader fahrenheit";
+  }
+
   return problem[0] + " degrees fahrenheit"
 
 

--- a/template1eqs/intocmfuncs.js
+++ b/template1eqs/intocmfuncs.js
@@ -68,6 +68,10 @@ function addintocm(main=false,self=intocmpreset,name=null){
 
 function intocmspeech(problem){
 
+  if(voiceLang.startsWith('sv')){
+    return problem[0] + " tum";
+  }
+
   return problem[0] + " inches"
 
 

--- a/template1eqs/kgtolbfuncs.js
+++ b/template1eqs/kgtolbfuncs.js
@@ -68,6 +68,10 @@ function addkgtolb(main=false,self=kgtolbpreset,name=null){
 
 function kgtolbspeech(problem){
 
+  if(voiceLang.startsWith('sv')){
+    return problem[0] + " kilogram";
+  }
+
   return problem[0] + " kilograms"
 
 

--- a/template1eqs/lbtokgfuncs.js
+++ b/template1eqs/lbtokgfuncs.js
@@ -68,6 +68,10 @@ function addlbtokg(main=false,self=lbtokgpreset,name=null){
 
 function lbtokgspeech(problem){
 
+  if(voiceLang.startsWith('sv')){
+    return problem[0] + " pund";
+  }
+
   return problem[0] + " pounds"
 
 

--- a/template1eqs/linearsystem.js
+++ b/template1eqs/linearsystem.js
@@ -135,11 +135,16 @@ function linearspeech(problem){
 
   let clone = [...problem]
 
-  clone[0] = clone[0] < 0 ? ("negative " + clone[0]) : clone[0];
-  clone[2] = clone[2] < 0 ? ("negative " + clone[2]) : clone[2];
+  clone[0] = clone[0] < 0 ? (voiceLang.startsWith('sv') ? "minus " + Math.abs(clone[0]) : "negative " + Math.abs(clone[0])) : clone[0];
+  clone[2] = clone[2] < 0 ? (voiceLang.startsWith('sv') ? "minus " + Math.abs(clone[2]) : "negative " + Math.abs(clone[2])) : clone[2];
 
-  clone[1] = clone[1] < 0 ? ("minus " + clone[1]) : ("plus " + clone[1]);
-  clone[3] = clone[3] < 0 ? ("minus " + clone[3]) : ("plus " + clone[3]);
+  clone[1] = clone[1] < 0 ? ("minus " + Math.abs(clone[1])) : (voiceLang.startsWith('sv') ? "plus " + clone[1] : "plus " + clone[1]);
+  clone[3] = clone[3] < 0 ? ("minus " + Math.abs(clone[3])) : (voiceLang.startsWith('sv') ? "plus " + clone[3] : "plus " + clone[3]);
+
+  if(voiceLang.startsWith('sv')){
+    let full = clone[0] + " " + clone[1] + " är lika med " + clone[2] + " " + clone[3];
+    return full;
+  }
 
   let full = clone[0] + " " + clone[1] + " equals " + clone[2] + " " + clone[3];
 

--- a/template1eqs/multfuncs.js
+++ b/template1eqs/multfuncs.js
@@ -86,6 +86,10 @@ function addmult(main=false,self=multpreset,name=null){
 
 function multspeech(problem){
 
+  if(voiceLang.startsWith('sv')){
+    return (problem[0] < 0 ? "minus " : "") + Math.abs(problem[0]) + " gånger " + (problem[1] < 0 ? "minus " : "") + Math.abs(problem[1]);
+  }
+
   return (problem[0] < 0 ? "negative " : "") + Math.abs(problem[0]) + " times " + (problem[1] < 0 ? "negative " : "") + Math.abs(problem[1]);
 
 }

--- a/template1eqs/percentagefuncs.js
+++ b/template1eqs/percentagefuncs.js
@@ -341,6 +341,10 @@ function addpercentage(main=false,self=percentagepreset,name=null){
 
 function percentagespeech(problem){
 
+  if(voiceLang.startsWith('sv')){
+    return problem[1] + " procent av " + problem[0];
+  }
+
   return problem[1] + " percent of " + problem[0]
 
 }

--- a/template1eqs/powerfuncs.js
+++ b/template1eqs/powerfuncs.js
@@ -98,6 +98,10 @@ function addpower(main=false,self=powerpreset,name=null){
 
 function powerspeech(problem){
 
+  if(voiceLang.startsWith('sv')){
+    return (problem[0] < 0 ? "minus " : "") + Math.abs(problem[0]) + " upphöjt till " + (problem[1] < 0 ? "minus " : "") + Math.abs(problem[1]);
+  }
+
   return (problem[0] < 0 ? "negative " : "") + Math.abs(problem[0]) + " to the power of " + (problem[1] < 0 ? "negative " : "") + Math.abs(problem[1]);
 
 }

--- a/template1eqs/quadraticeqs.js
+++ b/template1eqs/quadraticeqs.js
@@ -98,6 +98,10 @@ function quadraticspeech(problem){
   let lincoeff = problem[0] * problem[3] + problem[1] * problem[2];
   let constant = problem[2] * problem[3];
 
+  if(voiceLang.startsWith('sv')){
+    return `${coeff == 1 ? '' : coeff} x kvadrat ${lincoeff < 0 ? 'minus' : 'plus'} ${Math.abs(lincoeff) == 1 ? '' : Math.abs(lincoeff)} x ${constant < 0 ? 'minus' : 'plus'} ${Math.abs(constant)} `;
+  }
+
   return `${coeff == 1 ? "" : coeff} x squared ${lincoeff < 0 ? "minus" : "plus"} ${Math.abs(lincoeff) == 1 ? "" : Math.abs(lincoeff)} x ${constant < 0 ? "minus" : "plus"} ${Math.abs(constant)} `
 
 }

--- a/template1eqs/rootfuncs.js
+++ b/template1eqs/rootfuncs.js
@@ -111,6 +111,14 @@ function rootspeech(problem){
   if(problem[0] == 2) rootpart = "square root"
   if(problem[0] == 3) rootpart = "cube root"
 
+  if(voiceLang.startsWith('sv')){
+    if(problem[0] == 1) rootpart = "första roten";
+    if(problem[0] == 2) rootpart = "kvadratrot";
+    if(problem[0] == 3) rootpart = "kubikrot";
+    if(problem[0] > 3) rootpart = problem[0] + ":e roten";
+    return rootpart + " av " + problem[1];
+  }
+
   return rootpart + " of " + problem[1];
 
 }

--- a/template1eqs/subtractionfuncs.js
+++ b/template1eqs/subtractionfuncs.js
@@ -85,6 +85,10 @@ function addsubtraction(main=false,self=subtractionpreset,name=null){
 
 function subtractionspeech(problem){
 
+  if(voiceLang.startsWith('sv')){
+    return (problem[0] < 0 ? "minus " : "") + Math.abs(problem[0]) + " minus " + (problem[1] < 0 ? "minus " : "") + Math.abs(problem[1]);
+  }
+
   return (problem[0] < 0 ? "negative " : "") + Math.abs(problem[0]) + " minus " + (problem[1] < 0 ? "negative " : "") + Math.abs(problem[1]);
 
 

--- a/template1eqs/trigfuncs.js
+++ b/template1eqs/trigfuncs.js
@@ -69,9 +69,16 @@ function trigspeech(problem){
 
   let functionstring = "";
 
+  if(voiceLang.startsWith('sv')){
+    if(func == "sin") functionstring = "sinus";
+    if(func == "cos") functionstring = "kosinus";
+    if(func == "tan") functionstring = "tangens";
+    return functionstring + " för " + fraction[0] + " pi över " + fraction[1];
+  }
+
   if(func == "sin") functionstring = "sign";
   if(func == "cos") functionstring = "co-sign";
-  if(func = "tan") functionstring = "tan";
+  if(func == "tan") functionstring = "tan";
 
   return functionstring + " of " + fraction[0] + " pie over " + fraction[1];
 

--- a/template1eqs/voice.js
+++ b/template1eqs/voice.js
@@ -2,6 +2,7 @@
 let voicemodeenabled = false;
 let voicerate = 1;
 let voicevolume = 1;
+let voiceLang = 'en-US';
 
 
 function voicemodeclick(yarr=true){
@@ -75,6 +76,10 @@ function setvoicesliders(doinit){
   document.getElementById("voicevolumeslider").volume = Math.round((voicevolume)*7);
 }
 
+function setvoiceLanguage(lang){
+  voiceLang = lang;
+}
+
 function removevoicecontainer(event, bypass){
 
   if(!bypass && event.target.id != "voicecontainer") return
@@ -88,6 +93,7 @@ function removevoicecontainer(event, bypass){
 function showvoicecontainer(){
 
   document.getElementById("voicecontainer").style.display = "";
+  document.getElementById("voicelanguage").value = voiceLang;
 
 }
 
@@ -100,12 +106,10 @@ function synthesisvoice(text){
 
 
   for(var i = 0; i < voices.length; i++){
-
-    if(voices[i] == "en-US"){
+    if(voices[i].lang && voices[i].lang.startsWith(voiceLang)){
       utterThis.voice = voices[i];
+      break;
     }
-
-
   }
 
   console.log(voicevolume);


### PR DESCRIPTION
## Summary
- allow selecting a speech language
- hook the new setting in the voice dialog
- support Swedish phrases in equation speech functions
- fix a small bug in trigonometry speech

## Testing
- `for f in template1eqs/*.js; do node -c "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_68728b0aa6a8832795c8ac570593f373